### PR TITLE
Wallenda, isfinite replaced with saturator on output

### DIFF
--- a/src/composites/KSDelay.h
+++ b/src/composites/KSDelay.h
@@ -313,7 +313,7 @@ inline void KSDelayComp<TBase>::step()
         float out = crossfade (in, wet, mix);
 
         out = dcOutFilters[i].process (out);
-        out = std::isfinite (out) ? out : 0.0f;
+        out = sspo::voltageSaturate (out);
         lastOut[i] = out;
 
         TBase::outputs[OUT_OUTPUT].setVoltage (out, i);


### PR DESCRIPTION
It only affects the output if the signal is hot, now correctly saturated.